### PR TITLE
styled-componentsのバージョン指定

### DIFF
--- a/features/smarthr-preview/smarthr-preview.component.tsx
+++ b/features/smarthr-preview/smarthr-preview.component.tsx
@@ -9,7 +9,6 @@ export const SmartHRUIPreview: React.FC<ComponentProps<typeof Sandpack>> = (prop
       customSetup={{
         dependencies: {
           'smarthr-ui': 'latest',
-          'smarthr-normalize-css': 'latest',
           'styled-components': 'latest',
         },
       }}

--- a/features/smarthr-preview/smarthr-preview.component.tsx
+++ b/features/smarthr-preview/smarthr-preview.component.tsx
@@ -9,6 +9,7 @@ export const SmartHRUIPreview: React.FC<ComponentProps<typeof Sandpack>> = (prop
       customSetup={{
         dependencies: {
           'smarthr-ui': 'latest',
+          'smarthr-normalize-css': '5.3.9',
           'styled-components': 'latest',
         },
       }}

--- a/features/smarthr-preview/smarthr-preview.component.tsx
+++ b/features/smarthr-preview/smarthr-preview.component.tsx
@@ -9,8 +9,8 @@ export const SmartHRUIPreview: React.FC<ComponentProps<typeof Sandpack>> = (prop
       customSetup={{
         dependencies: {
           'smarthr-ui': 'latest',
-          'smarthr-normalize-css': '5.3.9',
-          'styled-components': 'latest',
+          'smarthr-normalize-css': 'latest',
+          'styled-components': '5.3.9',
         },
       }}
       options={{


### PR DESCRIPTION
> dropped deprecated withComponent API ([87f511a](https://github.com/styled-components/styled-components/commit/87f511a228e5b13b1ff70a416409e0705e5bf456)); use “as” prop instead
https://github.com/styled-components/styled-components/releases/tag/v6.0.0-rc.1

withComponentが非推奨になるため、旧バージョンを指定